### PR TITLE
Update Plugin Version to ver.5 so that it matches Client Version

### DIFF
--- a/vendor/github.com/hashicorp/go-plugin/server.go
+++ b/vendor/github.com/hashicorp/go-plugin/server.go
@@ -18,7 +18,7 @@ import (
 // will invalidate any prior plugins but will at least allow us to iterate
 // on the core in a safe way. We will do our best to do this very
 // infrequently.
-const CoreProtocolVersion = 1
+const CoreProtocolVersion = 5
 
 // HandshakeConfig is the configuration used by client and servers to
 // handshake before starting a plugin connection. This is embedded by


### PR DESCRIPTION
Current issue: 
Error: Failed to instantiate provider "sendmail" to obtain schema: Incompatible API version with plugin. Plugin version: 1, Client versions: [5]

@roboll 
Please review and build a new version of sendemail plugin, if possible